### PR TITLE
Release rust-diffusion 0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,16 @@
 [package]
 
 name = "diffusion"
-version = "0.0.1"
+version = "0.5.1"
 authors = ["Wangshan Lu <wisagan@gmail.com>"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/WiSaGaN/rust-diffusion"
+homepage = "https://github.com/WiSaGaN/rust-diffusion"
+description = """
+This is the rust implementation of diffusion library. Diffusion is an effcient message-based data distribution library.
+"""
+
 
 [[bin]]
 


### PR DESCRIPTION
Ready for cargo publish to crates.io.
